### PR TITLE
Add blogs tab with eye care articles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import Dashboard from "./pages/Dashboard";
 import Profile from "./pages/Profile";
 import Friends from "./pages/Friends";
 import Reports from "./pages/Reports";
+import Blogs from "./pages/Blogs";
+import BlogArticle from "./pages/BlogArticle";
 import Setup from "./pages/Setup";
 import Statistics from "./pages/Statistics";
 import IshiharaTest from "./pages/tests/IshiharaTest";
@@ -32,6 +34,8 @@ const App = () => (
           <Route path="/profile" element={<Profile />} />
           <Route path="/friends" element={<Friends />} />
           <Route path="/reports" element={<Reports />} />
+          <Route path="/blogs" element={<Blogs />} />
+          <Route path="/blogs/:slug" element={<BlogArticle />} />
           <Route path="/statistics" element={<Statistics />} />
           <Route path="/tests/ishihara" element={<IshiharaTest />} />
           <Route path="/tests/visual-acuity" element={<VisualAcuityTest />} />

--- a/src/pages/BlogArticle.tsx
+++ b/src/pages/BlogArticle.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, CalendarDays, Clock, Share2 } from "lucide-react";
+import { BLOG_POSTS } from "@/utils/blogPosts";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export default function BlogArticle() {
+  const navigate = useNavigate();
+  const { slug } = useParams();
+
+  const post = useMemo(() => BLOG_POSTS.find((item) => item.slug === slug), [slug]);
+
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+    } catch (error) {
+      console.error("share link error", error);
+    }
+  };
+
+  if (!post) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+        <Card className="max-w-lg border border-primary/20 bg-white/80 p-8 text-center shadow-xl backdrop-blur dark:bg-slate-900/70">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">Article not found</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            The blog you’re looking for isn’t available yet. Explore our latest insights while we publish more stories.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Button onClick={() => navigate("/blogs")}>Browse blogs</Button>
+            <Button variant="outline" onClick={() => navigate("/dashboard")}>
+              Go to dashboard
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+      <header className="border-b border-border/40 bg-card/70 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+            <div className="flex flex-col">
+              <span className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/80">AIris Blog</span>
+              <span className="text-lg font-bold text-slate-900 dark:text-slate-50">{post.title}</span>
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            className="hidden items-center gap-2 text-primary hover:bg-primary/10 dark:hover:bg-primary/20 sm:inline-flex"
+            onClick={handleShare}
+          >
+            <Share2 className="h-4 w-4" />
+            Share
+          </Button>
+        </div>
+      </header>
+
+      <main className="container mx-auto max-w-4xl space-y-10 px-4 py-10">
+        <section className={`relative overflow-hidden rounded-[32px] border border-primary/20 bg-gradient-to-br ${post.heroGradient} p-10 text-white shadow-2xl`}>
+          <span className="pointer-events-none absolute -top-12 left-8 h-32 w-32 rounded-full bg-white/30 blur-3xl" />
+          <span className="pointer-events-none absolute -bottom-16 right-10 h-40 w-40 rounded-full bg-white/20 blur-3xl" />
+          <div className="relative z-10 space-y-4">
+            <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+              <CalendarDays className="h-4 w-4" /> {post.publishDate}
+            </p>
+            <h1 className="text-3xl font-bold sm:text-4xl">{post.title}</h1>
+            <p className="max-w-2xl text-base text-white/80">{post.description}</p>
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-2 text-sm font-medium text-white">
+              <Clock className="h-4 w-4" />
+              {post.readTime}
+            </div>
+          </div>
+        </section>
+
+        <article className="space-y-12">
+          {post.sections.map((section) => (
+            <section key={section.heading} className="space-y-4 rounded-3xl border border-border/40 bg-white/80 p-8 shadow-lg backdrop-blur dark:border-white/10 dark:bg-slate-900/70">
+              <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">{section.heading}</h2>
+              {section.paragraphs.map((paragraph) => (
+                <p key={paragraph} className="text-base leading-relaxed text-slate-700 dark:text-slate-200">
+                  {paragraph}
+                </p>
+              ))}
+              {section.tips && section.tips.length > 0 && (
+                <div className="rounded-2xl bg-primary/10 p-5 text-sm text-primary dark:bg-primary/20">
+                  <p className="font-semibold uppercase tracking-[0.3em] text-xs text-primary/80">Try this</p>
+                  <ul className="mt-3 list-disc space-y-2 pl-5">
+                    {section.tips.map((tip) => (
+                      <li key={tip}>{tip}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </section>
+          ))}
+        </article>
+
+        <section className="grid gap-6 rounded-3xl border border-border/40 bg-white/80 p-8 shadow-lg backdrop-blur dark:border-white/10 dark:bg-slate-900/70 md:grid-cols-2">
+          <div className="space-y-3">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Key takeaways</h3>
+            <ul className="list-disc space-y-2 pl-5 text-sm text-slate-700 dark:text-slate-200">
+              {post.keyTakeaways.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+          {post.resources && post.resources.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Further resources</h3>
+              <ul className="space-y-2 text-sm text-primary">
+                {post.resources.map((resource) => (
+                  <li key={resource.url}>
+                    <a
+                      href={resource.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline transition-colors hover:text-primary/80"
+                    >
+                      {resource.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+
+        <section className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-primary/15 bg-gradient-to-r from-primary/10 via-sky-100 to-indigo-100 p-6 shadow-xl dark:from-slate-900 dark:via-primary/15 dark:to-indigo-950">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">Next steps</p>
+            <h3 className="mt-2 text-xl font-semibold text-slate-900 dark:text-slate-50">Ready for personalized vision coaching?</h3>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              Head back to your dashboard to track habits, schedule tests, and unlock new AIris recommendations tailored to you.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={() => navigate("/dashboard")}>Return to dashboard</Button>
+            <Button variant="outline" onClick={() => navigate("/blogs")}>Browse more blogs</Button>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/Blogs.tsx
+++ b/src/pages/Blogs.tsx
@@ -1,0 +1,113 @@
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft, BookOpenText, Clock, Plus } from "lucide-react";
+import logo from "@/assets/logo.png";
+import { BLOG_POSTS } from "@/utils/blogPosts";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Blogs() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+      <header className="border-b border-border/40 bg-card/70 backdrop-blur supports-[backdrop-filter]:bg-card/60">
+        <div className="container mx-auto flex items-center gap-3 px-4 py-4">
+          <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div
+            className="flex cursor-pointer items-center gap-3"
+            onClick={() => navigate("/dashboard")}
+          >
+            <img src={logo} alt="AIris" className="hidden h-10 sm:block" />
+            <div className="flex flex-col">
+              <span className="text-lg font-bold bg-gradient-to-r from-primary to-blue-600 bg-clip-text text-transparent">
+                AIris Insights
+              </span>
+              <span className="text-[10px] text-muted-foreground -mt-1">Eye care guides & wellness tips</span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto max-w-5xl space-y-10 px-4 py-10">
+        <section className="relative overflow-hidden rounded-[32px] border border-primary/15 bg-gradient-to-br from-primary/10 via-sky-100 to-indigo-100 p-8 shadow-xl dark:from-slate-900 dark:via-primary/15 dark:to-indigo-950">
+          <span className="pointer-events-none absolute -top-12 left-8 h-32 w-32 rounded-full bg-white/50 blur-3xl dark:bg-primary/30" />
+          <span className="pointer-events-none absolute -bottom-16 right-10 h-40 w-40 rounded-full bg-primary/20 blur-3xl dark:bg-indigo-500/30" />
+          <div className="relative z-10 space-y-4 text-slate-900 dark:text-slate-100">
+            <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-primary">
+              <BookOpenText className="h-4 w-4" />
+              Expert eye care blog
+            </p>
+            <h1 className="text-3xl font-bold sm:text-4xl">Stay inspired with actionable tips for brighter, healthier vision</h1>
+            <p className="max-w-2xl text-sm text-slate-700 dark:text-slate-300">
+              Dive into curated articles crafted by our vision specialists. Each guide translates clinical advice into everyday routines you can follow with confidence.
+            </p>
+            <Button
+              onClick={() => navigate("/dashboard")}
+              variant="outline"
+              className="mt-4 inline-flex items-center gap-2 rounded-full border-primary/60 bg-white/60 px-6 text-primary shadow-sm hover:bg-white/80 dark:border-primary/40 dark:bg-slate-900/70 dark:text-primary-foreground dark:hover:bg-slate-900"
+            >
+              <Plus className="h-4 w-4" />
+              Explore your personalized insights
+            </Button>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">Latest reads</p>
+              <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-50">Featured eye care stories</h2>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                Click any title to open the full article. We will keep expanding this library with new perspectives.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              className="inline-flex items-center gap-2 text-primary hover:bg-primary/10 dark:hover:bg-primary/20"
+              disabled
+            >
+              Coming soon
+            </Button>
+          </div>
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            {BLOG_POSTS.map((post) => (
+              <Card
+                key={post.slug}
+                className="group relative overflow-hidden border border-transparent bg-white/80 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:shadow-2xl dark:bg-slate-900/70"
+              >
+                <span className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${post.heroGradient} opacity-0 transition-opacity duration-500 group-hover:opacity-10`} />
+                <CardHeader className="relative space-y-3">
+                  <CardTitle
+                    onClick={() => navigate(`/blogs/${post.slug}`)}
+                    className="cursor-pointer text-xl font-semibold text-slate-900 transition-colors hover:text-primary dark:text-slate-50 dark:hover:text-primary"
+                  >
+                    {post.title}
+                  </CardTitle>
+                  <CardDescription className="text-sm text-slate-600 dark:text-slate-300">
+                    {post.description}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="relative flex items-center justify-between text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                  <span>{post.publishDate}</span>
+                  <span className="inline-flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {post.readTime}
+                  </span>
+                </CardContent>
+                <button
+                  onClick={() => navigate(`/blogs/${post.slug}`)}
+                  className="absolute inset-0"
+                  aria-label={`Read ${post.title}`}
+                />
+              </Card>
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -308,6 +308,11 @@ export default function Dashboard() {
       action: () => navigate("/statistics"),
     },
     {
+      label: "Read Eye Care Blogs",
+      icon: BookOpen,
+      action: () => navigate("/blogs"),
+    },
+    {
       label: "Invite Friends",
       icon: Users,
       action: () => navigate("/friends"),
@@ -339,19 +344,23 @@ export default function Dashboard() {
             </div>
           </div>
           <nav className="flex items-center gap-2">
-            <Button variant="ghost" onClick={() => navigate("/friends")}> 
+            <Button variant="ghost" onClick={() => navigate("/friends")}>
               <Users className="mr-2 h-4 w-4" />
               Friends
             </Button>
-            <Button variant="ghost" onClick={() => navigate("/reports")}> 
+            <Button variant="ghost" onClick={() => navigate("/reports")}>
               <FileText className="mr-2 h-4 w-4" />
               Reports
             </Button>
-            <Button variant="ghost" onClick={() => navigate("/statistics")}> 
+            <Button variant="ghost" onClick={() => navigate("/statistics")}>
               <Award className="mr-2 h-4 w-4" />
               Statistics
             </Button>
-            <Button variant="ghost" onClick={() => navigate("/profile")}> 
+            <Button variant="ghost" onClick={() => navigate("/blogs")}>
+              <BookOpen className="mr-2 h-4 w-4" />
+              Blogs
+            </Button>
+            <Button variant="ghost" onClick={() => navigate("/profile")}>
               <User className="mr-2 h-4 w-4" />
               Profile
             </Button>

--- a/src/utils/blogPosts.ts
+++ b/src/utils/blogPosts.ts
@@ -1,0 +1,184 @@
+export type BlogSection = {
+  heading: string;
+  paragraphs: string[];
+  tips?: string[];
+};
+
+export type BlogResource = {
+  label: string;
+  url: string;
+};
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  description: string;
+  heroGradient: string;
+  readTime: string;
+  publishDate: string;
+  sections: BlogSection[];
+  keyTakeaways: string[];
+  resources?: BlogResource[];
+};
+
+export const BLOG_POSTS: BlogPost[] = [
+  {
+    slug: "protect-your-vision-daily-habits",
+    title: "Protect Your Vision: Daily Habits That Support Healthy Eyes",
+    description:
+      "Discover simple, science-backed routines that reduce digital eye strain and keep your vision sharp from morning to night.",
+    heroGradient: "from-sky-500 via-blue-500 to-indigo-500",
+    readTime: "6 min read",
+    publishDate: "February 2025",
+    sections: [
+      {
+        heading: "Start Your Day with Eye-Friendly Rituals",
+        paragraphs: [
+          "Before screens take over your morning, hydrate and nourish your eyes. A glass of water replenishes tears that evaporated overnight, while a breakfast rich in vitamins A, C, and E provides antioxidants that protect the retina.",
+          "When you check your phone, lower the brightness or enable night mode. Sudden bursts of blue light can make eyes feel dry before the day truly begins."
+        ],
+        tips: [
+          "Add leafy greens, eggs, or citrus fruits to your breakfast for a vision-supporting boost.",
+          "Apply a warm compress for 60 seconds to loosen oil glands and prevent dry eyes."
+        ]
+      },
+      {
+        heading: "Build Micro-Breaks into Screen Time",
+        paragraphs: [
+          "Most of us blink 60% less when staring at screens, which destabilizes the tear film. Use the 20-20-20 rule as your anchor: every 20 minutes, look 20 feet away for at least 20 seconds.",
+          "Pair the habit with posture cues. Align your screen slightly below eye level and keep the top third of the monitor in your natural line of sight to reduce neck and eye strain simultaneously."
+        ],
+        tips: [
+          "Set calendar nudges or use productivity apps that dim the display when it’s time to look away.",
+          "Adjust ambient lighting so your screen isn’t the brightest object in the room."
+        ]
+      },
+      {
+        heading: "Wind Down with Recovery Techniques",
+        paragraphs: [
+          "Just like muscles, your eyes need a cool-down. Gentle palming—cupping your hands over closed eyes without pressure—encourages relaxation and blocks blue light.",
+          "Finish with five minutes of distance gazing. Focusing on objects across the room relaxes the ciliary muscles responsible for near work, leaving your eyes refreshed for tomorrow."
+        ],
+        tips: [
+          "Dim your screens or enable bedtime modes at least an hour before sleep to preserve melatonin production.",
+          "If you wear contacts, give your corneas a break overnight and stick to your replacement schedule."
+        ]
+      }
+    ],
+    keyTakeaways: [
+      "Hydration, nutrition, and blue-light awareness set the tone for comfortable eyes all day.",
+      "Micro-breaks plus posture support keep digital strain at bay during long work sessions.",
+      "Evenings are the perfect time to reset with recovery techniques that prepare your eyes for quality sleep."
+    ],
+    resources: [
+      { label: "American Academy of Ophthalmology: Digital Eye Strain", url: "https://www.aao.org/eye-health/tips-prevention/computer-usage" },
+      { label: "National Eye Institute: Healthy Vision Tips", url: "https://www.nei.nih.gov/learn-about-eye-health/healthy-vision" }
+    ]
+  },
+  {
+    slug: "nutrition-for-clear-vision",
+    title: "Nutrition for Clear Vision: Foods That Fuel Eye Health",
+    description:
+      "Fuel your eyes with nutrient-dense meals featuring carotenoids, omega-3s, and hydration strategies that protect sight long term.",
+    heroGradient: "from-emerald-500 via-teal-500 to-cyan-500",
+    readTime: "7 min read",
+    publishDate: "January 2025",
+    sections: [
+      {
+        heading: "Why Your Retina Loves Colorful Produce",
+        paragraphs: [
+          "Lutein and zeaxanthin act like internal sunglasses for the macula. These carotenoids filter high-energy light and neutralize oxidative stress, two of the biggest threats to central vision.",
+          "Aim for a rainbow on your plate. Dark leafy greens, orange peppers, and corn are tasty sources that pair well with healthy fats for better absorption."
+        ],
+        tips: [
+          "Blend spinach, mango, and Greek yogurt for a quick breakfast smoothie rich in carotenoids and protein.",
+          "Roast rainbow carrots with olive oil to unlock fat-soluble nutrients."
+        ]
+      },
+      {
+        heading: "Omega-3s Support Tear Quality",
+        paragraphs: [
+          "Dry eye often stems from poor oil layer quality in tears. Omega-3 fatty acids replenish that layer, helping tears stay on the eye longer.",
+          "Fatty fish like salmon or plant-based sources like flaxseed and chia can deliver the daily dose."
+        ],
+        tips: [
+          "Swap one meat-based meal each week for grilled salmon or sardines.",
+          "Add ground flaxseed to oatmeal for a plant-powered boost."
+        ]
+      },
+      {
+        heading: "Hydration Habits that Protect Vision",
+        paragraphs: [
+          "Every tear you produce relies on water. Mild dehydration leads to burning, blurry vision, and difficulty wearing contacts.",
+          "Keep a refillable bottle nearby and set mini goals—like finishing a glass before each meal—to stay consistent."
+        ],
+        tips: [
+          "Infuse water with citrus or cucumber to make sipping more inviting.",
+          "Limit dehydrating beverages like energy drinks, especially during focused work sessions."
+        ]
+      }
+    ],
+    keyTakeaways: [
+      "Carotenoids from leafy greens and brightly colored produce defend against macular damage.",
+      "Omega-3 fatty acids keep the tear film stable and comfortable.",
+      "Hydration is an underrated way to maintain clear, comfortable vision."
+    ],
+    resources: [
+      { label: "Harvard School of Public Health: Fats and Cholesterol", url: "https://www.hsph.harvard.edu/nutritionsource/what-should-you-eat/fats-and-cholesterol/" },
+      { label: "National Eye Institute: Nutrition", url: "https://www.nei.nih.gov/learn-about-eye-health/healthy-vision/nutrition" }
+    ]
+  },
+  {
+    slug: "how-to-talk-to-your-eye-doctor",
+    title: "How to Talk to Your Eye Doctor: Questions That Lead to Better Care",
+    description:
+      "Walk into your next eye exam prepared. These conversation starters ensure you understand changes in your vision and leave with a tailored action plan.",
+    heroGradient: "from-fuchsia-500 via-purple-500 to-blue-500",
+    readTime: "5 min read",
+    publishDate: "December 2024",
+    sections: [
+      {
+        heading: "Share a Complete Vision Story",
+        paragraphs: [
+          "Start with specifics: when did symptoms begin, how often do they appear, and what makes them better or worse? The clearer your story, the faster your doctor can pinpoint root causes.",
+          "Bring a log of screen time, medications, and supplements. Many prescriptions—from antihistamines to acne medications—can subtly impact tear production and focusing ability."
+        ],
+        tips: [
+          "Keep a simple note on your phone documenting flare-ups or visual changes.",
+          "List current eyewear prescriptions so adjustments can be tracked accurately."
+        ]
+      },
+      {
+        heading: "Ask About Preventive Screenings",
+        paragraphs: [
+          "If you have risk factors for glaucoma, macular degeneration, or diabetes, ask which tests are appropriate and how often they should be scheduled.",
+          "Understanding baseline images from retinal photos or OCT scans makes it easier to spot changes later."
+        ],
+        tips: [
+          "Request digital copies of any imaging so you can compare year over year.",
+          "Clarify insurance coverage or out-of-pocket costs ahead of time to avoid surprises."
+        ]
+      },
+      {
+        heading: "Clarify Your Next Steps",
+        paragraphs: [
+          "Before leaving, summarize what you heard: new prescriptions, follow-up appointments, lifestyle tweaks, and warning signs that warrant a call.",
+          "Schedule the next visit while you’re still at the front desk—many eye conditions benefit from consistent monitoring."
+        ],
+        tips: [
+          "Set reminders in your calendar for follow-up visits or contact lens refills.",
+          "If you were given new drops or medications, ask for written instructions and possible side effects."
+        ]
+      }
+    ],
+    keyTakeaways: [
+      "Detailed symptom tracking accelerates accurate diagnoses.",
+      "Preventive screenings protect long-term vision, especially for high-risk individuals.",
+      "Clear action steps and scheduled follow-ups keep your care plan on track."
+    ],
+    resources: [
+      { label: "American Optometric Association: Comprehensive Eye Exam", url: "https://www.aoa.org/healthy-eyes/caring-for-your-eyes/eye-exam" },
+      { label: "Centers for Disease Control and Prevention: Eye Care", url: "https://www.cdc.gov/visionhealth/resources/features/keep-eye-on-vision-health.html" }
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- add a blogs overview page with curated eye care content cards
- wire up individual article view backed by a reusable blog post dataset
- expose the new blogs tab from the dashboard navigation alongside existing quick actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f667a1ca848323a889cd15c9d99bff